### PR TITLE
Save params in update variable

### DIFF
--- a/lib/invoiced/operations/update.rb
+++ b/lib/invoiced/operations/update.rb
@@ -8,7 +8,7 @@ module Invoiced
                     update[k] = @values[k]
                 end
 
-                update.merge(params)
+                update = update.merge(params)
 
                 # perform the update if there are any changes
                 if update.length > 0


### PR DESCRIPTION
Updates were never occurring if the `@unsaved` variable was empty. Although params were being merged into `update`, this merge wasn't being saved.

This PR does a small fix to save those parameters

I have not written a unit test on this, as there were some Gemfile versioning conflicts to deal with. I'm not sure what decisions you'd like to make there, so I'll leave it to you to write a unit test for this if you like.

Thanks!