### PR TITLE
Require JWT in the client

### DIFF
--- a/lib/invoiced.rb
+++ b/lib/invoiced.rb
@@ -1,4 +1,5 @@
 require 'rest-client'
+require 'jwt'
 require 'json'
 require 'base64'
 

--- a/test/invoiced/invoiced_test.rb
+++ b/test/invoiced/invoiced_test.rb
@@ -2,7 +2,6 @@ require 'invoiced'
 require 'test/unit'
 require 'mocha/setup'
 require 'shoulda'
-require 'jwt'
 
 module Invoiced
   class InvoicedTest < Test::Unit::TestCase


### PR DESCRIPTION
Generating an SSO token involves the use of JWT, but the JWT gem was not required in the `Invoiced::Client` class. Added the require and removed it from the test file (since it's now required by the client).