### PR TITLE
bump rest-client gem version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 gemspec
 
-gem 'rest-client', '~> 2.0.0'
+gem 'rest-client', '~> 2.1.0'
 gem 'jwt', '~> 2.0'
 
 gem 'mocha', '~> 0.13.2', :require => false, :group => :test

--- a/invoiced.gemspec
+++ b/invoiced.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://invoiced.com/docs/dev'
   s.required_ruby_version = '>= 2.1.0'
 
-  s.add_dependency('rest-client', '~> 2.0.0')
+  s.add_dependency('rest-client', '~> 2.1.0')
   s.add_dependency('jwt', '~> 2.0')
 
   s.files = `git ls-files`.split("\n")

--- a/lib/invoiced/version.rb
+++ b/lib/invoiced/version.rb
@@ -1,3 +1,3 @@
 module Invoiced
-  VERSION = '2.1.0'
+  VERSION = '2.2.0'
 end


### PR DESCRIPTION
This dependency bump is to resolve compatibility issues with other gems that depend on `rest-client ~> 2.1.0`

POST MERGE TODO: cut & release new minor gem version to update dependency